### PR TITLE
Fix dedicated-server crash in SpeakerAmbientPacketHandler clinit

### DIFF
--- a/src/main/java/com/micatechnologies/minecraft/csm/technology/SpeakerAmbientPacketHandler.java
+++ b/src/main/java/com/micatechnologies/minecraft/csm/technology/SpeakerAmbientPacketHandler.java
@@ -23,7 +23,16 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 public class SpeakerAmbientPacketHandler
     implements IMessageHandler<SpeakerAmbientPacket, IMessage> {
 
-  @SideOnly(Side.CLIENT)
+  /**
+   * Active sounds keyed by the speaker block position. Intentionally NOT marked
+   * {@code @SideOnly(Side.CLIENT)} on the field declaration: Forge strips annotated
+   * fields on the wrong side, but the static-initializer bytecode that assigns a fresh
+   * {@code HashMap<>()} is left intact, so server-side class loading (which happens
+   * during network-message registration) would crash with NoSuchFieldError. The map's
+   * generic value type is erased at runtime, so {@code SpeakerAmbientSound} only needs
+   * to resolve at the use sites — and those use sites are already gated by
+   * {@code @SideOnly(Side.CLIENT)} on the methods that touch it.
+   */
   private static final Map<BlockPos, SpeakerAmbientSound> ACTIVE_SOUNDS = new HashMap<>();
 
   @Override


### PR DESCRIPTION
The ACTIVE_SOUNDS field was annotated @SideOnly(Side.CLIENT). Forge's side-stripping removes annotated FIELDS at runtime, but it doesn't touch the static-initializer bytecode that assigns to them — so when the dedicated server loads the handler class during network-message registration (SimpleNetworkWrapper.instantiate calls Class.newInstance which triggers <clinit>), the bytecode tries to PUTSTATIC into a field that no longer exists on the server and crashes with NoSuchFieldError: ACTIVE_SOUNDS.

Drop the @SideOnly annotation on the field. The field's generic value type SpeakerAmbientSound is erased at runtime, so the class itself doesn't need to resolve until the @SideOnly methods that use it actually run (which only happens on the client). Matches the pattern the working FireAlarmSoundPacketHandler already uses.

Comment in the file documents the gotcha so a future edit doesn't re-add the annotation.