### PR TITLE
Fix release publish broken by the buildscript update banner

### DIFF
--- a/.github/workflows/build-mod-release-pre-release-main.yml
+++ b/.github/workflows/build-mod-release-pre-release-main.yml
@@ -78,24 +78,30 @@ jobs:
       - name: Assemble Mod with Gradle
         run: ./gradlew build -Dhttp.socketTimeout=60000 -Dhttp.connectionTimeout=60000 -Dorg.gradle.internal.http.socketTimeout=60000 -Dorg.gradle.internal.http.connectionTimeout=60000
 
+      # `| tail -n 1`: these values are pasted into a filename by the publish step below, so
+      # any stray stdout line corrupts the release. Gradle prints banners during project
+      # evaluation even under -q — the buildscript update check did exactly that on
+      # 2026-07-27 and the release died on `cp ./build/libs/Build script update available!...`.
+      # Taking the last line keeps the print task's own output. gradle.properties disables
+      # that particular check at the source; this is the belt-and-braces half.
       - name: Save Mod Name to GITHUB_ENV
         run: |
-          modName=$(${{github.workspace}}/gradlew -q printModName | xargs)
+          modName=$(${{github.workspace}}/gradlew -q printModName | tail -n 1 | xargs)
           echo "MOD_NAME=$modName" >> $GITHUB_ENV
 
       - name: Save Mod Version to GITHUB_ENV
         run: |
-          modVersion=$(${{github.workspace}}/gradlew -q printModVersion | xargs)
+          modVersion=$(${{github.workspace}}/gradlew -q printModVersion | tail -n 1 | xargs)
           echo "MOD_VERSION=$modVersion" >> $GITHUB_ENV
 
       - name: Save Mod Archive Base Name to GITHUB_ENV
         run: |
-          modArchiveBaseName=$(${{github.workspace}}/gradlew -q printArchivesBaseName | xargs)
+          modArchiveBaseName=$(${{github.workspace}}/gradlew -q printArchivesBaseName | tail -n 1 | xargs)
           echo "MOD_ARCHIVE_BASE_NAME=$modArchiveBaseName" >> $GITHUB_ENV
 
       - name: Save Minecraft Version to GITHUB_ENV
         run: |
-          minecraftVersion=$(${{github.workspace}}/gradlew -q printMinecraftVersion | xargs)
+          minecraftVersion=$(${{github.workspace}}/gradlew -q printMinecraftVersion | tail -n 1 | xargs)
           echo "MINECRAFT_VERSION=$minecraftVersion" >> $GITHUB_ENV
 
       - name: Copy Assembled Mod Jar to GitHub Actions Workspace

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,4 @@
-//version: 1777224609
+//version: 1784768619
 /*
  * DO NOT CHANGE THIS FILE!
  * Also, you may replace this file at any time if there is an update available.
@@ -34,6 +34,9 @@ plugins {
     id 'eclipse'
     id 'maven-publish'
     id 'org.jetbrains.gradle.plugin.idea-ext' version '1.1.8'
+    // LOCAL CHANGE (re-apply after every updateBuildScript): upstream ships 1.4.0, which was
+    // removed from all public repos and now resolves only from stale local caches. 1.4.7 is the
+    // oldest version still published. See d61a2bb63.
     id 'com.gtnewhorizons.retrofuturagradle' version '1.4.7'
     id 'net.darkhax.curseforgegradle' version '1.1.24' apply false
     id 'com.modrinth.minotaur' version '2.8.7' apply false
@@ -97,6 +100,8 @@ propertyDefaultIfUnset("modrinthRelations", "")
 propertyDefaultIfUnsetWithEnvVar("curseForgeProjectId", "", "CURSEFORGE_PROJECT_ID")
 propertyDefaultIfUnset("curseForgeRelations", "")
 propertyDefaultIfUnsetWithEnvVar("releaseType", "release", "RELEASE_TYPE")
+propertyDefaultIfUnset("clientEnvironment", true)
+propertyDefaultIfUnset("serverEnvironment", true)
 propertyDefaultIfUnset("generateDefaultChangelog", false)
 propertyDefaultIfUnset("customMavenPublishUrl", "")
 propertyDefaultIfUnset("mavenArtifactGroup", getDefaultArtifactGroup())
@@ -1207,6 +1212,12 @@ if (cfApiKey.isPresent() || deploymentDebug.toBoolean()) {
             mainFile.addModLoader 'Forge'
             mainFile.addJavaVersion "Java 8"
             mainFile.addGameVersion minecraftVersion
+            if (serverEnvironment.toBoolean()) {
+                mainFile.addEnvironment "Server"
+            }
+            if (clientEnvironment.toBoolean()) {
+                mainFile.addEnvironment "Client"
+            }
 
             if (curseForgeRelations.size() != 0) {
                 String[] deps = curseForgeRelations.split(';')

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,6 +5,22 @@
 #
 
 
+# Disable the GTCEu buildscript's configuration-time "is a newer build.gradle available?"
+# check (build.gradle guards it with Boolean.getBoolean('DISABLE_BUILDSCRIPT_UPDATE_CHECK')).
+#
+# The check prints "Build script update available! Run 'gradle updateBuildScript'" to stdout
+# during project evaluation — including under `gradlew -q`. The release workflow captures
+# `gradlew -q printModName` and friends straight into GITHUB_ENV, so on 2026-07-27 the banner
+# was concatenated into MOD_NAME / MOD_VERSION / MOD_ARCHIVE_BASE_NAME and the publish step ran
+# `cp ./build/libs/Build script update available! ... .jar`, failing the release with no jar
+# published. The check also fetches raw.githubusercontent.com at configuration time, which can
+# hard-fail CI on a socket timeout.
+#
+# We don't want the auto-update anyway: it overwrites build.gradle and reverts our RFG 1.4.7
+# pin (1.4.0 no longer resolves from public repos). Run `gradlew updateBuildScript` by hand
+# when a refresh is wanted, then re-apply the pin.
+systemProp.DISABLE_BUILDSCRIPT_UPDATE_CHECK = true
+
 # Gradle Settings
 # Effectively applies the '--stacktrace' flag by default
 org.gradle.logging.stacktrace = all


### PR DESCRIPTION
The 2026.07.26 release run failed and published nothing. The "Copy Assembled Mod Jar" step ran:

    cp ./build/libs/Build script update available! Run gradle \
       updateBuildScript minecraft-city-super-mod-Build script update \
       available! Run gradle updateBuildScript 2026.07.26.jar ./

The workflow builds that filename out of GITHUB_ENV values captured with `gradlew -q printModName` and friends. build.gradle's configuration-time update check (line ~1411) had just started firing because upstream published a newer buildscript, and it prints

    Build script update available! Run 'gradle updateBuildScript'

to stdout during project evaluation — even under -q. That text was concatenated into MOD_NAME, MOD_VERSION and MOD_ARCHIVE_BASE_NAME. The build itself was fine; only publishing broke.

Three changes:

1. gradle.properties: systemProp.DISABLE_BUILDSCRIPT_UPDATE_CHECK = true, the guard build.gradle already reads. Kills the banner at the source and also drops a configuration-time fetch of raw.githubusercontent.com that can hard-fail CI on a socket timeout. SUM has carried this since 2026-07-18, which is why its releases were unaffected. autoUpdateBuildScript=false was NOT sufficient — it only suppresses auto-applying the update, not announcing it.

2. Ran `gradlew updateBuildScript` (1777224609 -> 1784768619) so the pending update is actually taken rather than deferred forever. Upstream delta is small: clientEnvironment/serverEnvironment property defaults and CurseForge environment tagging.

   The update reverted our RFG pin from 1.4.7 to upstream's 1.4.0, which no longer resolves from any public repo — restored, now with a comment marking it as a local change to re-apply after future updates. That pin is the only local modification this file has ever carried.

3. Hardened the four env captures with `| tail -n 1`. These values become a filename, so any future banner on stdout would break publishing the same way. Belt-and-braces behind change 1.

Verified locally: all four print tasks now yield clean values (MinecraftCitySuperMod / 1.12.2 / minecraft-city-super-mod / version), and `gradlew build` passes with the updated buildscript and restored pin.