### PR TITLE
CI: run Gradle on JDK 21

### DIFF
--- a/.github/workflows/build-mod-release-pre-release-main.yml
+++ b/.github/workflows/build-mod-release-pre-release-main.yml
@@ -22,11 +22,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Up JDK 17
+      # RFG runs the Gradle process on Java 21+ (compiler + mod code stay Java 8 via
+      # Jabel); older Gradle-JVM Java versions are deprecated and slated for removal.
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6

--- a/.github/workflows/test-mod-build-pr.yml
+++ b/.github/workflows/test-mod-build-pr.yml
@@ -17,11 +17,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Up JDK 17
+      # RFG runs the Gradle process on Java 21+ (compiler + mod code stay Java 8 via
+      # Jabel); older Gradle-JVM Java versions are deprecated and slated for removal.
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6
@@ -49,11 +51,13 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set Up JDK 17
+      # RFG runs the Gradle process on Java 21+ (compiler + mod code stay Java 8 via
+      # Jabel); older Gradle-JVM Java versions are deprecated and slated for removal.
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
-          java-version: '17'
+          java-version: '21'
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v6


### PR DESCRIPTION
RetroFuturaGradle prints a deprecation notice on every invocation under Java < 21 ("scheduled to be removed, please upgrade your local and CI workflow Java version to 21 or newer"), so CI was building on a toolchain RFG intends to drop. Bumps all three setup-java steps (release workflow plus both PR jobs) from 17 to 21.

Only the JVM that runs Gradle changes. The compiler and mod code still target Java 8 via Jabel, and pinned Gradle 8.9 supports running on up to Java 22, so 21 is inside its supported range.

Matches SUM, which moved to 21 in 5b252f3 and has been building on it since July with the same Gradle 8.9 / RFG 1.4.7 combination.

Note: the RFG notice goes to stderr, so it was never a factor in the release-publish breakage fixed by cc5447f68 — that was a stdout banner. This is housekeeping, not part of that fix.