### PR TITLE
Let other mods read the fire alarm linker's selection

### DIFF
--- a/src/main/java/com/micatechnologies/minecraft/csm/lifesafety/ItemFireAlarmLinker.java
+++ b/src/main/java/com/micatechnologies/minecraft/csm/lifesafety/ItemFireAlarmLinker.java
@@ -30,6 +30,27 @@ public class ItemFireAlarmLinker extends AbstractItem {
     super(0, 1);
   }
 
+  /**
+   * Gets the fire alarm control panel this linker currently has selected, or null if none has been
+   * selected yet.
+   * <p>
+   * Exposed so that other mods can take part in linking. The linker itself only knows how to attach
+   * CSM's own sounders and sensors to a panel, and teaching it about every block another mod might
+   * want to link would mean CSM knowing about those mods. Letting the other mod read the selection
+   * inverts that: it can handle its own blocks with this same tool, and CSM needs to know nothing
+   * about it.
+   * <p>
+   * Note the selection lives on the item instance, which is a singleton, so it is shared by everyone
+   * holding one. That is pre-existing behaviour and is fine in single player.
+   *
+   * @return the selected fire alarm control panel position, or null
+   *
+   * @since 2026.08.07
+   */
+  public BlockPos getSelectedPanel() {
+    return alarmPanelPos;
+  }
+
   @Override
   public EnumActionResult onItemUse(EntityPlayer player,
       World worldIn,


### PR DESCRIPTION
The linker knows how to attach CSM's own sounders and sensors to a panel, and nothing else -- it tests the clicked block against CSM classes, so a block from another mod falls straight through. Teaching it about every block somebody might want to link would mean CSM knowing about those mods.

Exposing the selected panel inverts that. Another mod can handle its own blocks with the same tool a builder is already holding, and CSM needs to know nothing about it. Purely additive: no existing behaviour changes and no caller is affected.

Prompted by LDMovingElevators, which recalls lifts to a floor when a paired panel sounds, and where being handed a second linking tool for the same job was the first thing that felt wrong.